### PR TITLE
Add Jest tests for all API endpoints

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "dependencies": {
     "express": "^4.18.2",
@@ -23,7 +23,9 @@
     "morgan": "^1.10.0"
   },
   "devDependencies": {
-    "nodemon": "^3.0.1"
+    "nodemon": "^3.0.1",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   },
   "keywords": [
     "express",

--- a/backend/server.js
+++ b/backend/server.js
@@ -37,14 +37,17 @@ app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 
 // Health check endpoint
-app.get('/health', (req, res) => {
+const healthHandler = (req, res) => {
   res.json({
     success: true,
     message: 'SideBet API is running',
     timestamp: new Date().toISOString(),
     environment: process.env.NODE_ENV
   });
-});
+};
+
+app.get('/health', healthHandler);
+app.get('/api/health', healthHandler);
 
 // API routes
 app.use('/api', authRoutes);

--- a/backend/tests/endpoints.test.js
+++ b/backend/tests/endpoints.test.js
@@ -1,0 +1,108 @@
+const request = require('supertest');
+
+jest.mock('../config/database', () => ({
+  connectDB: jest.fn(),
+}));
+
+jest.mock('../middleware/auth', () => ({
+  protect: (req, res, next) => next(),
+  optionalAuth: (req, res, next) => next(),
+}));
+
+jest.mock('../controllers/authController', () => ({
+  register: (req, res) => res.status(201).json({ message: 'register handler' }),
+  login: (req, res) => res.json({ message: 'login handler' }),
+  getMe: (req, res) => res.json({ message: 'getMe handler' }),
+}));
+
+jest.mock('../controllers/betController', () => ({
+  createBet: (req, res) => res.status(201).json({ message: 'createBet handler' }),
+  getBet: (req, res) => res.json({ message: 'getBet handler' }),
+  acceptBet: (req, res) => res.json({ message: 'acceptBet handler' }),
+  getMyBets: (req, res) => res.json({ message: 'getMyBets handler' }),
+  getAllBets: (req, res) => res.json({ message: 'getAllBets handler' }),
+  deleteBet: (req, res) => res.json({ message: 'deleteBet handler' }),
+  markBetAsWon: (req, res) => res.json({ message: 'markBetAsWon handler' }),
+  markBetAsLost: (req, res) => res.json({ message: 'markBetAsLost handler' }),
+  getLeaderboard: (req, res) => res.json({ message: 'getLeaderboard handler' }),
+}));
+
+const app = require('../server');
+
+describe('API endpoints', () => {
+  test('GET /health', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+  });
+
+  test('GET /api/health', async () => {
+    const res = await request(app).get('/api/health');
+    expect(res.status).toBe(200);
+  });
+
+  test('POST /api/register', async () => {
+    const res = await request(app)
+      .post('/api/register')
+      .send({ email: 'test@example.com', password: 'password', name: 'Test' });
+    expect(res.status).toBe(201);
+  });
+
+  test('POST /api/login', async () => {
+    const res = await request(app)
+      .post('/api/login')
+      .send({ email: 'test@example.com', password: 'password' });
+    expect(res.status).toBe(200);
+  });
+
+  test('GET /api/me', async () => {
+    const res = await request(app).get('/api/me');
+    expect(res.status).toBe(200);
+  });
+
+  test('POST /api/bets', async () => {
+    const res = await request(app)
+      .post('/api/bets')
+      .send({ name: 'Bet', description: 'desc', size: 10 });
+    expect(res.status).toBe(201);
+  });
+
+  test('GET /api/bets/my-bets', async () => {
+    const res = await request(app).get('/api/bets/my-bets');
+    expect(res.status).toBe(200);
+  });
+
+  test('GET /api/bets', async () => {
+    const res = await request(app).get('/api/bets');
+    expect(res.status).toBe(200);
+  });
+
+  test('GET /api/bets/leaderboard', async () => {
+    const res = await request(app).get('/api/bets/leaderboard');
+    expect(res.status).toBe(200);
+  });
+
+  test('GET /api/bets/:id', async () => {
+    const res = await request(app).get('/api/bets/123');
+    expect(res.status).toBe(200);
+  });
+
+  test('POST /api/bets/:id/accept', async () => {
+    const res = await request(app).post('/api/bets/123/accept');
+    expect(res.status).toBe(200);
+  });
+
+  test('DELETE /api/bets/:id', async () => {
+    const res = await request(app).delete('/api/bets/123');
+    expect(res.status).toBe(200);
+  });
+
+  test('POST /api/bets/:id/mark-won', async () => {
+    const res = await request(app).post('/api/bets/123/mark-won');
+    expect(res.status).toBe(200);
+  });
+
+  test('POST /api/bets/:id/mark-lost', async () => {
+    const res = await request(app).post('/api/bets/123/mark-lost');
+    expect(res.status).toBe(200);
+  });
+});

--- a/backend/tests/health.test.js
+++ b/backend/tests/health.test.js
@@ -1,0 +1,18 @@
+const request = require('supertest');
+
+jest.mock('../config/database', () => ({
+  connectDB: jest.fn(),
+}));
+
+const app = require('../server');
+
+describe('GET /api/health', () => {
+  it('returns status 200 and expected JSON keys', async () => {
+    const res = await request(app).get('/api/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('success', true);
+    expect(res.body).toHaveProperty('message');
+    expect(res.body).toHaveProperty('timestamp');
+    expect(res.body).toHaveProperty('environment');
+  });
+});


### PR DESCRIPTION
## Summary
- keep /api/health handler exposed at both `/health` and `/api/health`
- configure backend to run tests with Jest
- add a new test suite that exercises all API endpoints using mocked controllers

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c17b40f7c8326a4bdb6d2529f482e